### PR TITLE
Switch back to psycopg2 (non-binary) dependency

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 django>=1.7
-psycopg2-binary
+psycopg2
 pytz; python_version < '3.3'
 typing; python_version < '3.5'


### PR DESCRIPTION
According to the maintainers of the `psycopg2` and `psycopg2-binary` packages, production software and libraries [should depend on](https://www.psycopg.org/docs/install.html#psycopg-vs-psycopg-binary) `psycopg2`:
> The psycopg2-binary package is meant for beginners to start playing with Python and PostgreSQL without the need to meet the build requirements.
> If you are the maintainer of a published package depending on psycopg2 you shouldn’t use psycopg2-binary as a module dependency. **For production use you are advised to use the source distribution.**

See [this thread](https://github.com/psycopg/psycopg2/issues/837#issuecomment-481773799) for additional context.