### PR TITLE
Add check for parent classes

### DIFF
--- a/src/django_pg_bulk_update/set_functions.py
+++ b/src/django_pg_bulk_update/set_functions.py
@@ -219,7 +219,7 @@ class AbstractSetFunction(AbstractFieldFormatter):
         if self.supported_field_classes is None:
             return True
         else:
-            return field.__class__.__name__  in self.supported_field_classes or self.is_parent_class_supported(field.__class__)
+            return field.__class__.__name__ in self.supported_field_classes or self.is_parent_class_supported(field.__class__)
 
     def _parse_null_default(self, field, connection, **kwargs):
         """

--- a/src/django_pg_bulk_update/set_functions.py
+++ b/src/django_pg_bulk_update/set_functions.py
@@ -205,8 +205,8 @@ class AbstractSetFunction(AbstractFieldFormatter):
                 for base in class_to_check.__bases__: mro.extend(recurse(base, recurse))
                 return mro
             mro = getmro(class_to_check, getmro)
-        for class in mro:
-            if class.__name__ in self.supported_field_classes:
+        for cl in mro:
+            if cl.__name__ in self.supported_field_classes:
                 return True
         return False
 


### PR DESCRIPTION
Checks all parents of class and if one of them is in supported_field_classes return True.
Needed for custom field classes, that inherit from supported field class.
For example if [ModificationDateTimeField](https://django-extensions.readthedocs.io/en/latest/field_extensions.html?highlight=ModificationDateTimeField) was used, result was error because it's class name was not in supported field classes, despite it inheriting from DateTimeField.
So now if class inherits from supported class it returns True.